### PR TITLE
Use `SystemUUID` in `Node` status to determine `ServerClaim`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.1
+          version: v1.60

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 ## Tool Versions
 ADDLICENSE_VERSION ?= v1.1.1
 GOIMPORTS_VERSION ?= v0.22.0
-GOLANGCI_LINT_VERSION ?= v1.59.1
+GOLANGCI_LINT_VERSION ?= v1.60.1
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.

--- a/cmd/metal-cloud-controller-manager/main.go
+++ b/cmd/metal-cloud-controller-manager/main.go
@@ -61,7 +61,7 @@ func cloudInitializer(config *cloudcontrollerconfig.CompletedConfig) cloudprovid
 		klog.Fatalf("Cloud provider is nil")
 	}
 
-	if !cloud.HasClusterID() {
+	if cloud != nil && !cloud.HasClusterID() {
 		if config.ComponentConfig.KubeCloudShared.AllowUntaggedCloud {
 			klog.Warning("detected a cluster without a ClusterID. A ClusterID will be required in the future. Please tag your cluster to avoid any future issues.")
 		} else {

--- a/pkg/cloudprovider/metal/instances_v2.go
+++ b/pkg/cloudprovider/metal/instances_v2.go
@@ -6,6 +6,7 @@ package metal
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -37,12 +38,12 @@ func (o *metalInstancesV2) InstanceExists(ctx context.Context, node *corev1.Node
 	}
 	klog.V(4).InfoS("Checking if node exists", "Node", node.Name)
 
-	serverClaim := &metalv1alpha1.ServerClaim{}
-	if err := o.metalClient.Get(ctx, client.ObjectKey{Namespace: o.metalNamespace, Name: node.Name}, serverClaim); err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, cloudprovider.InstanceNotFound
-		}
-		return false, fmt.Errorf("failed to get server claim object for node %s: %w", node.Name, err)
+	serverClaim, err := o.getServerClaimForNode(ctx, node)
+	if err != nil {
+		return false, err
+	}
+	if serverClaim == nil {
+		return false, cloudprovider.InstanceNotFound
 	}
 
 	klog.V(4).InfoS("Instance for node exists", "Node", node.Name, "ServerClaim", client.ObjectKeyFromObject(serverClaim))
@@ -55,12 +56,12 @@ func (o *metalInstancesV2) InstanceShutdown(ctx context.Context, node *corev1.No
 	}
 	klog.V(4).InfoS("Checking if instance is shut down", "Node", node.Name)
 
-	serverClaim := &metalv1alpha1.ServerClaim{}
-	if err := o.metalClient.Get(ctx, client.ObjectKey{Namespace: o.metalNamespace, Name: node.Name}, serverClaim); err != nil {
-		if apierrors.IsNotFound(err) {
-			return false, cloudprovider.InstanceNotFound
-		}
-		return false, fmt.Errorf("failed to get server claim object for node %s: %w", node.Name, err)
+	serverClaim, err := o.getServerClaimForNode(ctx, node)
+	if err != nil {
+		return false, err
+	}
+	if serverClaim == nil {
+		return false, cloudprovider.InstanceNotFound
 	}
 
 	server := &metalv1alpha1.Server{}
@@ -81,15 +82,18 @@ func (o *metalInstancesV2) InstanceMetadata(ctx context.Context, node *corev1.No
 		return nil, nil
 	}
 
-	serverClaim := &metalv1alpha1.ServerClaim{}
-	if err := o.metalClient.Get(ctx, client.ObjectKey{Namespace: o.metalNamespace, Name: node.Name}, serverClaim); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, cloudprovider.InstanceNotFound
-		}
-		return nil, fmt.Errorf("failed to get server claim object for node %s: %w", node.Name, err)
+	var serverClaim *metalv1alpha1.ServerClaim
+
+	serverClaim, err := o.getServerClaimForNode(ctx, node)
+	if err != nil {
+		return nil, err
 	}
 
-	//add label for clusterName to server claim object
+	if serverClaim == nil {
+		return nil, cloudprovider.InstanceNotFound
+	}
+
+	// Add label for clusterName to server claim object
 	serverClaimBase := serverClaim.DeepCopy()
 	if serverClaim.Labels == nil {
 		serverClaim.Labels = make(map[string]string)
@@ -141,5 +145,55 @@ func (o *metalInstancesV2) InstanceMetadata(ctx context.Context, node *corev1.No
 		NodeAddresses: addresses,
 		Zone:          zone,
 		Region:        region,
+	}, nil
+}
+
+func (o *metalInstancesV2) getServerClaimForNode(ctx context.Context, node *corev1.Node) (*metalv1alpha1.ServerClaim, error) {
+	var serverClaim *metalv1alpha1.ServerClaim
+	if node.Spec.ProviderID != "" {
+		return o.getServerClaimFromProviderID(ctx, node.Spec.ProviderID)
+	}
+
+	serverClaimList := &metalv1alpha1.ServerClaimList{}
+	if err := o.metalClient.List(ctx, serverClaimList, client.InNamespace(o.metalNamespace)); err != nil {
+		return nil, fmt.Errorf("failed to list server claims for node %s: %w", node.Name, err)
+	}
+
+	for _, claim := range serverClaimList.Items {
+		server := &metalv1alpha1.Server{}
+		if err := o.metalClient.Get(ctx, client.ObjectKey{Name: claim.Spec.ServerRef.Name}, server); err != nil {
+			return nil, fmt.Errorf("failed to get server object for node %s: %w", node.Name, err)
+		}
+		if nodeInfo := node.Status.NodeInfo; nodeInfo.SystemUUID == server.Spec.UUID {
+			return &claim, nil
+		}
+	}
+
+	return serverClaim, nil
+}
+
+func (o *metalInstancesV2) getServerClaimFromProviderID(ctx context.Context, providerID string) (*metalv1alpha1.ServerClaim, error) {
+	objKey, err := getObjectKeyFromProviderID(providerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get object key for ProviderID %s: %w", providerID, err)
+	}
+	serverClaim := &metalv1alpha1.ServerClaim{}
+	if err := o.metalClient.Get(ctx, objKey, serverClaim); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, cloudprovider.InstanceNotFound
+		}
+		return nil, fmt.Errorf("failed to get server claim object for ProviderID %s: %w", providerID, err)
+	}
+	return serverClaim, nil
+}
+
+func getObjectKeyFromProviderID(providerID string) (client.ObjectKey, error) {
+	parts := strings.Split(strings.TrimPrefix(providerID, fmt.Sprintf("%s://", ProviderName)), "/")
+	if len(parts) != 2 {
+		return client.ObjectKey{}, fmt.Errorf("invalid format of ProviderID %s", providerID)
+	}
+	return client.ObjectKey{
+		Namespace: parts[0],
+		Name:      parts[1],
 	}, nil
 }

--- a/pkg/cloudprovider/metal/instances_v2_test.go
+++ b/pkg/cloudprovider/metal/instances_v2_test.go
@@ -21,13 +21,15 @@ var _ = Describe("InstancesV2", func() {
 	)
 	ns, cp, clusterName := SetupTest()
 
-	It("should get instance info", func(ctx SpecContext) {
-		By("instantiating the instances v2 provider")
+	BeforeEach(func() {
+		By("Instantiating the instances v2 provider")
 		var ok bool
 		instancesProvider, ok = (*cp).InstancesV2()
 		Expect(ok).To(BeTrue())
+	})
 
-		By("creating a Server")
+	It("Should get instance info", func(ctx SpecContext) {
+		By("Creating a Server")
 		server := &metalv1alpha1.Server{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "test-",
@@ -45,7 +47,7 @@ var _ = Describe("InstancesV2", func() {
 		Expect(k8sClient.Create(ctx, server)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, server)
 
-		By("patching the Server object to have a valid network interface status")
+		By("Patching the Server object to have a valid network interface status")
 		Eventually(UpdateStatus(server, func() {
 			server.Status.PowerState = metalv1alpha1.ServerOnPowerState
 			server.Status.NetworkInterfaces = []metalv1alpha1.NetworkInterface{{
@@ -54,7 +56,7 @@ var _ = Describe("InstancesV2", func() {
 			}}
 		})).Should(Succeed())
 
-		By("creating a ServerClaim for a Node")
+		By("Creating a ServerClaim for a Node")
 		serverClaim := &metalv1alpha1.ServerClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace:    ns.Name,
@@ -68,26 +70,31 @@ var _ = Describe("InstancesV2", func() {
 		Expect(k8sClient.Create(ctx, serverClaim)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, serverClaim)
 
-		By("creating a node object with a provider ID referencing the machine")
+		By("Creating a Node object with a provider ID referencing the machine")
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: serverClaim.Name,
+				GenerateName: "test-",
 			},
 		}
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, node)
 
-		By("ensuring that an instance for a node exists")
+		By("Updating the SystemUUID in Node status")
+		Eventually(UpdateStatus(node, func() {
+			node.Status.NodeInfo.SystemUUID = "12345"
+		})).Should(Succeed())
+
+		By("Ensuring that an instance for a Node exists")
 		ok, err := instancesProvider.InstanceExists(ctx, node)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ok).To(BeTrue())
 
-		By("ensuring that the instance is not shut down")
+		By("Ensuring that the instance is not shut down")
 		ok, err = instancesProvider.InstanceShutdown(ctx, node)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ok).To(BeFalse())
 
-		By("ensuring that the instance meta data has the correct addresses")
+		By("Ensuring that the instance meta data has the correct addresses")
 		instanceMetadata, err := instancesProvider.InstanceMetadata(ctx, node)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(instanceMetadata).Should(SatisfyAll(
@@ -102,30 +109,118 @@ var _ = Describe("InstancesV2", func() {
 			HaveField("Zone", "a"),
 			HaveField("Region", "bar")))
 
-		By("ensuring cluster name label is added to ServerClaim object")
+		By("Ensuring cluster name label is added to ServerClaim object")
 		Eventually(Object(serverClaim)).Should(SatisfyAll(
 			HaveField("Labels", map[string]string{LabelKeyClusterName: clusterName}),
 		))
 	})
 
-	It("should get InstanceNotFound if no ServerClaim exists for Node", func(ctx SpecContext) {
-		By("creating a node object with a provider ID referencing non existing ServerClaim")
+	It("Should get instance info for a Node with correct ProviderID", func(ctx SpecContext) {
+		By("Creating a Server")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Labels: map[string]string{
+					"instance-type": "foo",
+					"zone":          "a",
+					"region":        "bar",
+				},
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				UUID:  "12345",
+				Power: "On",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server)
+
+		By("Patching the Server object to have a valid network interface status")
+		Eventually(UpdateStatus(server, func() {
+			server.Status.PowerState = metalv1alpha1.ServerOnPowerState
+			server.Status.NetworkInterfaces = []metalv1alpha1.NetworkInterface{{
+				Name: "my-nic",
+				IP:   metalv1alpha1.MustParseIP("10.0.0.1"),
+			}}
+		})).Should(Succeed())
+
+		By("Creating a ServerClaim for a Node")
+		serverClaim := &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-",
+			},
+			Spec: metalv1alpha1.ServerClaimSpec{
+				Power:     "On",
+				ServerRef: &corev1.LocalObjectReference{Name: server.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, serverClaim)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, serverClaim)
+
+		By("Creating a Node object with a provider ID referencing the machine")
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "foo",
+				GenerateName: "test-",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: getProviderID(serverClaim.Namespace, serverClaim.Name),
 			},
 		}
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, node)
 
-		By("ensuring that an instance for a node does not exist")
+		By("Ensuring that an instance for a Node exists")
+		ok, err := instancesProvider.InstanceExists(ctx, node)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		By("Ensuring that the instance is not shut down")
+		ok, err = instancesProvider.InstanceShutdown(ctx, node)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeFalse())
+
+		By("Ensuring that the instance meta data has the correct addresses")
+		instanceMetadata, err := instancesProvider.InstanceMetadata(ctx, node)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(instanceMetadata).Should(SatisfyAll(
+			HaveField("ProviderID", getProviderID(serverClaim.Namespace, serverClaim.Name)),
+			HaveField("InstanceType", "foo"),
+			HaveField("NodeAddresses", ContainElements(
+				corev1.NodeAddress{
+					Type:    corev1.NodeInternalIP,
+					Address: "10.0.0.1",
+				},
+			)),
+			HaveField("Zone", "a"),
+			HaveField("Region", "bar")))
+
+		By("Ensuring cluster name label is added to ServerClaim object")
+		Eventually(Object(serverClaim)).Should(SatisfyAll(
+			HaveField("Labels", map[string]string{LabelKeyClusterName: clusterName}),
+		))
+	})
+
+	It("Should get InstanceNotFound if no ServerClaim exists for Node", func(ctx SpecContext) {
+		By("Creating a Node object with a provider ID referencing non existing ServerClaim")
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: getProviderID(ns.Name, "bar"),
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, node)
+
+		By("Ensuring that an instance for a Node does not exist")
 		ok, err := instancesProvider.InstanceExists(ctx, node)
 		Expect(err).To(Equal(cloudprovider.InstanceNotFound))
 		Expect(ok).To(BeFalse())
 	})
 
-	It("should fail to get instance metadata if no ServerClaim exists for Node", func(ctx SpecContext) {
-		By("creating a node object with a provider ID referencing non existing ServerClaim")
+	It("Should fail to get instance metadata if no ServerClaim exists for Node", func(ctx SpecContext) {
+		By("Creating a node object with a provider ID referencing non existing ServerClaim")
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
@@ -134,14 +229,14 @@ var _ = Describe("InstancesV2", func() {
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())
 		DeferCleanup(k8sClient.Delete, node)
 
-		By("ensuring to fail getting the instance metadata")
+		By("Ensuring to fail getting the instance metadata")
 		metaData, err := instancesProvider.InstanceMetadata(ctx, node)
 		Expect(err).To(Equal(cloudprovider.InstanceNotFound))
 		Expect(metaData).To(BeNil())
 	})
 
-	It("should fail to get instance shutdown state if no ServerClaim exists for Node", func(ctx SpecContext) {
-		By("creating a node object with a provider ID referencing non existing ServerClaim")
+	It("Should fail to get instance shutdown state if no ServerClaim exists for Node", func(ctx SpecContext) {
+		By("Creating a Node object with a provider ID referencing non existing ServerClaim")
 		node := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",

--- a/pkg/cloudprovider/metal/suite_test.go
+++ b/pkg/cloudprovider/metal/suite_test.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	pollingInterval      = 50 * time.Millisecond
-	eventuallyTimeout    = 10 * time.Second
+	eventuallyTimeout    = 3 * time.Second
 	consistentlyDuration = 1 * time.Second
 )
 
@@ -145,7 +145,9 @@ func SetupTest() (*corev1.Namespace, *cloudprovider.Interface, string) {
 		defer func() {
 			_ = cloudConfigFile.Close()
 		}()
-		cloudConfig := CloudConfig{ClusterName: clusterName}
+		cloudConfig := CloudConfig{
+			ClusterName: clusterName,
+		}
 		cloudConfigData, err := yaml.Marshal(&cloudConfig)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.WriteFile(cloudConfigFile.Name(), cloudConfigData, 0666)).To(Succeed())
@@ -156,7 +158,7 @@ func SetupTest() (*corev1.Namespace, *cloudprovider.Interface, string) {
 		k8sClientSet, err := kubernetes.NewForConfig(cfg)
 		Expect(err).NotTo(HaveOccurred())
 
-		clientBuilder := clientbuilder.NewDynamicClientBuilder(testEnv.Config, k8sClientSet.CoreV1(), "default")
+		clientBuilder := clientbuilder.NewDynamicClientBuilder(testEnv.Config, k8sClientSet.CoreV1(), ns.Name)
 		cp, err = cloudprovider.InitCloudProvider(ProviderName, cloudConfigFile.Name())
 		Expect(err).NotTo(HaveOccurred())
 		cp.Initialize(clientBuilder, cloudProviderCtx.Done())


### PR DESCRIPTION
# Proposed Changes

- Use `SystemUUID` in `Node` status to determine `ServerClaim`
- Bump `golangci-lint` to 1.60
