### PR TITLE
Always search for lowercase SystemUUID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
+LABEL source_repository="https://github.com/ironcore-dev/cloud-provider-metal"
 WORKDIR /
 COPY --from=builder /workspace/manager /metal-cloud-controller-manager
 USER 65532:65532

--- a/pkg/cloudprovider/metal/instances_v2.go
+++ b/pkg/cloudprovider/metal/instances_v2.go
@@ -164,7 +164,8 @@ func (o *metalInstancesV2) getServerClaimForNode(ctx context.Context, node *core
 		if err := o.metalClient.Get(ctx, client.ObjectKey{Name: claim.Spec.ServerRef.Name}, server); err != nil {
 			return nil, fmt.Errorf("failed to get server object for node %s: %w", node.Name, err)
 		}
-		if nodeInfo := node.Status.NodeInfo; nodeInfo.SystemUUID == server.Spec.UUID {
+		//Avoid case mismatch by converting to lower case
+		if nodeInfo := node.Status.NodeInfo; nodeInfo.SystemUUID == strings.ToLower(server.Spec.UUID) {
 			return &claim, nil
 		}
 	}


### PR DESCRIPTION
# Proposed Changes

- `nodeInfo.SystemUUID` will always be in lowercase but for some vendors `server.Spec.UUID` is uppercase.
