### PR TITLE
Add kustomization for Cluster-API case

### DIFF
--- a/config/capi/deployment_patch.yaml
+++ b/config/capi/deployment_patch.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manager
+spec:
+  hostNetwork: true

--- a/config/capi/kustomization.yaml
+++ b/config/capi/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- ../default
+
+patches:
+- path: deployment_patch.yaml


### PR DESCRIPTION
# Proposed Changes

- configure hostNetwork for CCM deployment because in CAPI case it runs on the workload cluster and taint from node will not be removed if CCM cannot reach DNS (coredns pods are still `Pending `)
