### PR TITLE
Include `ServerClaim` UID in `Node` ProviderID

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,7 +9,7 @@ Source: https://github.com/ironcore-dev/cloud-provider-metal
 Files:
   .github/*
   .gitignore
-  .golangci.yaml
+  .golangci.yml
   .dockerignore
   CODE_OF_CONDUCT.md
   CODEOWNERS

--- a/pkg/cloudprovider/metal/instances_v2_test.go
+++ b/pkg/cloudprovider/metal/instances_v2_test.go
@@ -98,7 +98,7 @@ var _ = Describe("InstancesV2", func() {
 		instanceMetadata, err := instancesProvider.InstanceMetadata(ctx, node)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(instanceMetadata).Should(SatisfyAll(
-			HaveField("ProviderID", getProviderID(serverClaim.Namespace, serverClaim.Name)),
+			HaveField("ProviderID", getProviderIDForServerClaim(serverClaim)),
 			HaveField("InstanceType", "foo"),
 			HaveField("NodeAddresses", ContainElements(
 				corev1.NodeAddress{
@@ -163,7 +163,7 @@ var _ = Describe("InstancesV2", func() {
 				GenerateName: "test-",
 			},
 			Spec: corev1.NodeSpec{
-				ProviderID: getProviderID(serverClaim.Namespace, serverClaim.Name),
+				ProviderID: getProviderIDForServerClaim(serverClaim),
 			},
 		}
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())
@@ -183,7 +183,7 @@ var _ = Describe("InstancesV2", func() {
 		instanceMetadata, err := instancesProvider.InstanceMetadata(ctx, node)
 		Expect(err).NotTo(HaveOccurred())
 		Eventually(instanceMetadata).Should(SatisfyAll(
-			HaveField("ProviderID", getProviderID(serverClaim.Namespace, serverClaim.Name)),
+			HaveField("ProviderID", getProviderIDForServerClaim(serverClaim)),
 			HaveField("InstanceType", "foo"),
 			HaveField("NodeAddresses", ContainElements(
 				corev1.NodeAddress{
@@ -207,7 +207,7 @@ var _ = Describe("InstancesV2", func() {
 				Name: "foo",
 			},
 			Spec: corev1.NodeSpec{
-				ProviderID: getProviderID(ns.Name, "bar"),
+				ProviderID: fmt.Sprintf("%s://%s/foo/bar", ProviderName, ns.Name),
 			},
 		}
 		Expect(k8sClient.Create(ctx, node)).To(Succeed())
@@ -251,7 +251,3 @@ var _ = Describe("InstancesV2", func() {
 		Expect(ok).To(BeFalse())
 	})
 })
-
-func getProviderID(namespace, serverClaimName string) string {
-	return fmt.Sprintf("%s://%s/%s", ProviderName, namespace, serverClaimName)
-}


### PR DESCRIPTION
# Proposed Changes

Include `ServerClaim` UID in `Node` ProviderID.

```
providerID: metal://<namespace>/<serverclaim-name>/<serverclaim-uid>
```

Fixes #17