### PR TITLE
Make `NodeAddresses` Configuration optional

### DIFF
--- a/pkg/cloudprovider/metal/cloud.go
+++ b/pkg/cloudprovider/metal/cloud.go
@@ -80,7 +80,12 @@ func (o *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 		log.Fatalf("Failed to create new cluster: %v", err)
 	}
 
-	o.instancesV2 = newMetalInstancesV2(o.targetCluster.GetClient(), o.metalCluster.GetClient(), o.metalNamespace, o.cloudConfig.ClusterName)
+	o.instancesV2 = newMetalInstancesV2(
+		o.targetCluster.GetClient(),
+		o.metalCluster.GetClient(),
+		o.metalNamespace,
+		o.cloudConfig,
+	)
 
 	if err := o.metalCluster.GetFieldIndexer().IndexField(ctx, &metalv1alpha1.ServerClaim{}, serverClaimMetadataUIDField, func(object client.Object) []string {
 		serverClaim := object.(*metalv1alpha1.ServerClaim)

--- a/pkg/cloudprovider/metal/cloud_test.go
+++ b/pkg/cloudprovider/metal/cloud_test.go
@@ -9,7 +9,13 @@ import (
 )
 
 var _ = Describe("Cloud", func() {
-	_, cp, _ := SetupTest()
+	cloudConfig := CloudConfig{
+		ClusterName: clusterName,
+		Networking: Networking{
+			ConfigureNodeAddresses: true,
+		},
+	}
+	_, cp, _ := SetupTest(cloudConfig)
 
 	It("should ensure the correct cloud provider setup", func() {
 		Expect((*cp).HasClusterID()).To(BeTrue())

--- a/pkg/cloudprovider/metal/config.go
+++ b/pkg/cloudprovider/metal/config.go
@@ -22,8 +22,13 @@ type CloudProviderConfig struct {
 	cloudConfig CloudConfig
 }
 
+type NetworkingOpts struct {
+	ConfigureNodeAddresses bool `json:"configureNodeAddresses"`
+}
+
 type CloudConfig struct {
-	ClusterName string `json:"clusterName"`
+	ClusterName string         `json:"clusterName"`
+	Networking  NetworkingOpts `json:"networkingOpts"`
 }
 
 var (

--- a/pkg/cloudprovider/metal/config.go
+++ b/pkg/cloudprovider/metal/config.go
@@ -22,13 +22,13 @@ type CloudProviderConfig struct {
 	cloudConfig CloudConfig
 }
 
-type NetworkingOpts struct {
+type Networking struct {
 	ConfigureNodeAddresses bool `json:"configureNodeAddresses"`
 }
 
 type CloudConfig struct {
-	ClusterName string         `json:"clusterName"`
-	Networking  NetworkingOpts `json:"networkingOpts"`
+	ClusterName string     `json:"clusterName"`
+	Networking  Networking `json:"networking"`
 }
 
 var (

--- a/pkg/cloudprovider/metal/instances_v2_test.go
+++ b/pkg/cloudprovider/metal/instances_v2_test.go
@@ -4,15 +4,23 @@
 package metal
 
 import (
+	"context"
 	"fmt"
+	"os"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/controller-manager/pkg/clientbuilder"
 	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	"sigs.k8s.io/yaml"
 )
 
 var _ = Describe("InstancesV2", func() {
@@ -249,6 +257,146 @@ var _ = Describe("InstancesV2", func() {
 		ok, err := instancesProvider.InstanceShutdown(ctx, node)
 		Expect(err).To(Equal(cloudprovider.InstanceNotFound))
 		Expect(ok).To(BeFalse())
+	})
+
+	It("Should not configure node addresses if ConfigureNodeAddresses is false", func(ctx SpecContext) {
+		By("Starting up a cloud provider with cloud config to disable node address configuration")
+		user, err := testEnv.AddUser(envtest.User{
+			Name:   "dummy",
+			Groups: []string{"system:authenticated", "system:masters"},
+		}, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		kubeconfigData, err := user.KubeConfig()
+		Expect(err).NotTo(HaveOccurred())
+
+		clientConfig, err := clientcmd.Load(kubeconfigData)
+		Expect(err).NotTo(HaveOccurred())
+		clientConfig.Contexts[clientConfig.CurrentContext].Namespace = ns.Name
+
+		namespacedKubeconfigData, err := clientcmd.Write(*clientConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		kubeconfigFile, err := os.CreateTemp(GinkgoT().TempDir(), "kubeconfig")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			_ = kubeconfigFile.Close()
+		}()
+		Expect(os.WriteFile(kubeconfigFile.Name(), namespacedKubeconfigData, 0666)).To(Succeed())
+
+		curr := MetalKubeconfigPath
+		defer func() {
+			MetalKubeconfigPath = curr
+		}()
+		MetalKubeconfigPath = kubeconfigFile.Name()
+
+		cloudConfigFile, err := os.CreateTemp(GinkgoT().TempDir(), "cloud.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() {
+			_ = cloudConfigFile.Close()
+		}()
+		cloudConfig := CloudConfig{
+			ClusterName: clusterName,
+			Networking: Networking{
+				ConfigureNodeAddresses: false,
+			},
+		}
+		cloudConfigData, err := yaml.Marshal(&cloudConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(cloudConfigFile.Name(), cloudConfigData, 0666)).To(Succeed())
+
+		cloudProviderCtx, cancel := context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+
+		k8sClientSet, err := kubernetes.NewForConfig(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		clientBuilder := clientbuilder.NewDynamicClientBuilder(testEnv.Config, k8sClientSet.CoreV1(), ns.Name)
+		cp, err := cloudprovider.InitCloudProvider(ProviderName, cloudConfigFile.Name())
+		Expect(err).NotTo(HaveOccurred())
+		cp.Initialize(clientBuilder, cloudProviderCtx.Done())
+
+		By("Instantiating the instances v2 provider")
+		instancesProvider, ok := cp.InstancesV2()
+		Expect(ok).To(BeTrue())
+
+		By("Creating a Server")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Labels: map[string]string{
+					"instance-type": "foo",
+					"zone":          "a",
+					"region":        "bar",
+				},
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				UUID:  "12345",
+				Power: "On",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server)
+
+		By("Patching the Server object to have a valid network interface status")
+		Eventually(UpdateStatus(server, func() {
+			server.Status.PowerState = metalv1alpha1.ServerOnPowerState
+			server.Status.NetworkInterfaces = []metalv1alpha1.NetworkInterface{{
+				Name: "my-nic",
+				IP:   metalv1alpha1.MustParseIP("10.0.0.1"),
+			}}
+		})).Should(Succeed())
+
+		By("Creating a ServerClaim for a Node")
+		serverClaim := &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-",
+			},
+			Spec: metalv1alpha1.ServerClaimSpec{
+				Power:     "On",
+				ServerRef: &corev1.LocalObjectReference{Name: server.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, serverClaim)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, serverClaim)
+
+		By("Creating a Node object with a provider ID referencing the machine")
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+			Spec: corev1.NodeSpec{
+				ProviderID: getProviderID(serverClaim.Namespace, serverClaim.Name),
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, node)
+
+		By("Ensuring that an instance for a Node exists")
+		ok, err = instancesProvider.InstanceExists(ctx, node)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		By("Ensuring that the instance is not shut down")
+		ok, err = instancesProvider.InstanceShutdown(ctx, node)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeFalse())
+
+		By("Ensuring that the instance meta data has empty addresses")
+		instanceMetadata, err := instancesProvider.InstanceMetadata(ctx, node)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(instanceMetadata).Should(SatisfyAll(
+			HaveField("ProviderID", getProviderID(serverClaim.Namespace, serverClaim.Name)),
+			HaveField("InstanceType", "foo"),
+			HaveField("NodeAddresses", BeEmpty()),
+			HaveField("Zone", "a"),
+			HaveField("Region", "bar")))
+
+		By("Ensuring cluster name label is added to ServerClaim object")
+		Eventually(Object(serverClaim)).Should(SatisfyAll(
+			HaveField("Labels", map[string]string{LabelKeyClusterName: clusterName}),
+		))
 	})
 })
 

--- a/pkg/cloudprovider/metal/instances_v2_test.go
+++ b/pkg/cloudprovider/metal/instances_v2_test.go
@@ -260,7 +260,7 @@ var _ = Describe("InstancesV2", func() {
 	})
 })
 
-var _ = Describe("InstancesV2", func() {
+var _ = Describe("InstancesV2 with modified CloudConfig", func() {
 	cloudConfig := CloudConfig{
 		ClusterName: clusterName,
 		Networking: Networking{

--- a/pkg/cloudprovider/metal/suite_test.go
+++ b/pkg/cloudprovider/metal/suite_test.go
@@ -147,6 +147,9 @@ func SetupTest() (*corev1.Namespace, *cloudprovider.Interface, string) {
 		}()
 		cloudConfig := CloudConfig{
 			ClusterName: clusterName,
+			Networking: NetworkingOpts{
+				ConfigureNodeAddresses: true,
+			},
 		}
 		cloudConfigData, err := yaml.Marshal(&cloudConfig)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/cloudprovider/metal/suite_test.go
+++ b/pkg/cloudprovider/metal/suite_test.go
@@ -147,7 +147,7 @@ func SetupTest() (*corev1.Namespace, *cloudprovider.Interface, string) {
 		}()
 		cloudConfig := CloudConfig{
 			ClusterName: clusterName,
-			Networking: NetworkingOpts{
+			Networking: Networking{
 				ConfigureNodeAddresses: true,
 			},
 		}

--- a/pkg/cloudprovider/metal/suite_test.go
+++ b/pkg/cloudprovider/metal/suite_test.go
@@ -97,11 +97,10 @@ var _ = BeforeSuite(func() {
 	SetClient(k8sClient)
 })
 
-func SetupTest() (*corev1.Namespace, *cloudprovider.Interface, string) {
+func SetupTest(cloudConfig CloudConfig) (*corev1.Namespace, *cloudprovider.Interface, string) {
 	var (
-		ns          = &corev1.Namespace{}
-		cp          cloudprovider.Interface
-		clusterName = "test"
+		ns = &corev1.Namespace{}
+		cp cloudprovider.Interface
 	)
 
 	BeforeEach(func(ctx SpecContext) {
@@ -145,12 +144,6 @@ func SetupTest() (*corev1.Namespace, *cloudprovider.Interface, string) {
 		defer func() {
 			_ = cloudConfigFile.Close()
 		}()
-		cloudConfig := CloudConfig{
-			ClusterName: clusterName,
-			Networking: Networking{
-				ConfigureNodeAddresses: true,
-			},
-		}
 		cloudConfigData, err := yaml.Marshal(&cloudConfig)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.WriteFile(cloudConfigFile.Name(), cloudConfigData, 0666)).To(Succeed())
@@ -167,5 +160,5 @@ func SetupTest() (*corev1.Namespace, *cloudprovider.Interface, string) {
 		cp.Initialize(clientBuilder, cloudProviderCtx.Done())
 	})
 
-	return ns, &cp, clusterName
+	return ns, &cp, cloudConfig.ClusterName
 }


### PR DESCRIPTION
# Proposed Changes

- add network options to the config (easier to extend) that has an ability to enable/disable node address configuration

Tested in capi cluster to use node `internal-ip` other than discovery one:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: cloud-provider-config
  namespace: kube-system
data:
  cloudprovider.conf: |
    clusterName: capi-cluster
    networking:
      configureNodeAddresses: false
```

Fixes https://github.com/ironcore-dev/cloud-provider-metal/issues/18