### PR TITLE
Add `metal.ironcore.dev/power-off` annotation

### DIFF
--- a/pkg/cloudprovider/metal/constants.go
+++ b/pkg/cloudprovider/metal/constants.go
@@ -12,6 +12,8 @@ const (
 	AnnotationKeyServiceNamespace = "service-namespace"
 	// AnnotationKeyServiceUID is the service UID annotation key name
 	AnnotationKeyServiceUID = "service-uid"
+	// AnnotationPowerOff can be set to any value to power off a server
+	AnnotationPowerOff = "metal.ironcore.dev/power-off"
 	// LabelKeyClusterName is the label key name used to identify the cluster name in Kubernetes labels
 	LabelKeyClusterName = "kubernetes.io/cluster"
 )


### PR DESCRIPTION
# Proposed Changes

- Add `metal.ironcore.dev/power-off`, which can be attached to a node object to power off the backing `ServerClaim`