### PR TITLE
Retrieve node ip addresses via owning ServerClaim

### DIFF
--- a/pkg/cloudprovider/metal/constants.go
+++ b/pkg/cloudprovider/metal/constants.go
@@ -16,4 +16,6 @@ const (
 	AnnotationPowerOff = "metal.ironcore.dev/power-off"
 	// LabelKeyClusterName is the label key name used to identify the cluster name in Kubernetes labels
 	LabelKeyClusterName = "kubernetes.io/cluster"
+	// LabelKeyServerClaim is the label key name used to identify the server claim in Kubernetes labels
+	LabelKeyServerClaim = "metal.ironcore.dev/server-claim"
 )


### PR DESCRIPTION
# Proposed Changes

Previously, node IPs were found by matching the name of the `ServerClaim`. This doesn't work well, if multiple IPs are allocated for a node. I would propose that the capi- and mcm-provider create the `IPAddressClaims` and attach the owning `ServerClaim` as owner ref and label. This way the `IPAddressClaims` for a `ServerClaim` can be identified (and garbaged collected automatically).