### PR TITLE
Refactor IP address claim labels to use separate name and namespace keys

### DIFF
--- a/pkg/cloudprovider/metal/constants.go
+++ b/pkg/cloudprovider/metal/constants.go
@@ -16,6 +16,8 @@ const (
 	AnnotationPowerOff = "metal.ironcore.dev/power-off"
 	// LabelKeyClusterName is the label key name used to identify the cluster name in Kubernetes labels
 	LabelKeyClusterName = "kubernetes.io/cluster"
-	// LabelKeyServerClaim is the label key name used to identify the server claim in Kubernetes labels
-	LabelKeyServerClaim = "metal.ironcore.dev/server-claim"
+	// LabelKeyServerClaimName is the label key name used to identify the server claim's name in Kubernetes labels
+	LabelKeyServerClaimName = "metal.ironcore.dev/server-claim-name"
+	// LabelKeyServerClaimNamespace is the label key name used to identify the server claim's namespace in Kubernetes labels
+	LabelKeyServerClaimNamespace = "metal.ironcore.dev/server-claim-namespace"
 )

--- a/pkg/cloudprovider/metal/instances_v2.go
+++ b/pkg/cloudprovider/metal/instances_v2.go
@@ -165,7 +165,10 @@ func (o *metalInstancesV2) getNodeAddresses(ctx context.Context, server *metalv1
 	}
 	ipamKind := o.cloudConfig.Networking.IPAMKind
 	if ipamKind.APIGroup == capiv1beta1.GroupVersion.Group && ipamKind.Kind == "IPAddress" {
-		selector := client.MatchingLabels{LabelKeyServerClaim: claim.Namespace + "_" + claim.Name}
+		selector := client.MatchingLabels{
+			LabelKeyServerClaimName:      claim.Name,
+			LabelKeyServerClaimNamespace: claim.Namespace,
+		}
 		var allIpClaims capiv1beta1.IPAddressClaimList
 		if err := o.metalClient.List(ctx, &allIpClaims, client.InNamespace(o.metalNamespace), selector); err != nil {
 			return nil, err


### PR DESCRIPTION
# Proposed Changes

This change is needed because having name and namespace in one label can exceed label length limit.