### PR TITLE
Update `k8s.io/*` to v0.32 in tests

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -16,9 +16,18 @@ on:
     paths-ignore:
       - 'docs/**'
       - '**/*.md'
+    types: [labeled, unlabeled, opened, synchronize, reopened]
 
 jobs:
   buildAndPush:
+    permissions:
+      contents: read
+      packages: write
+    # Condition: Run on push to main, published release, OR PR with 'ok-to-image' label
+    if: |
+      github.event_name == 'push' || 
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ok-to-image')) ||
+      (github.event_name == 'release' && github.event.action == 'published')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 CONTROLLER_IMG ?= controller:latest
 
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.31.0
+ENVTEST_K8S_VERSION = 1.32.0
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/ironcore-dev/cloud-provider-metal
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.24.0
 
 require (
 	github.com/ironcore-dev/controller-utils v0.9.8

--- a/pkg/cloudprovider/metal/suite_test.go
+++ b/pkg/cloudprovider/metal/suite_test.go
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
 		BinaryAssetsDirectory: filepath.Join("..", "..", "..", "bin", "k8s",
-			fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
+			fmt.Sprintf("1.32.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 
 	var err error


### PR DESCRIPTION
# Proposed Changes

- Update k8s.io/* in tests to v0.32
- Update container build workflow
- Bump golang to v1.24
