### PR TITLE
Add `ServerClaim` controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.36.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20240227224415-6ceb2ff114de // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250528174236-200df99c418a // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
 github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/evanphx/json-patch v5.7.0+incompatible h1:vgGkfT/9f8zE6tvSCe74nfpAVDQ2tG6yudJd8LBksgI=
+github.com/evanphx/json-patch v5.7.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/pkg/cloudprovider/metal/serverclaim_controller.go
+++ b/pkg/cloudprovider/metal/serverclaim_controller.go
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	nodeProviderIDField string        = ".spec.providerID"
+	baseDelay           time.Duration = 5 * time.Second
+	maxDelay            time.Duration = 5 * time.Minute
+)
+
+type ServerClaimReconciler struct {
+	metalClient  client.Client
+	targetClient client.Client
+	informer     ctrlcache.Informer
+	queue        workqueue.TypedRateLimitingInterface[types.NamespacedName]
+}
+
+func NewServerClaimReconciler(targetClient client.Client, metalClient client.Client, claimInformer ctrlcache.Informer) ServerClaimReconciler {
+	rateLimiter := workqueue.NewTypedItemExponentialFailureRateLimiter[types.NamespacedName](baseDelay, maxDelay)
+	queue := workqueue.NewTypedRateLimitingQueue(rateLimiter)
+	return ServerClaimReconciler{
+		targetClient: targetClient,
+		metalClient:  metalClient,
+		informer:     claimInformer,
+		queue:        queue,
+	}
+}
+
+func (r *ServerClaimReconciler) Start(ctx context.Context) error {
+	_, err := r.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			claim, ok := obj.(*metalv1alpha1.ServerClaim)
+			if !ok {
+				klog.Errorf("unexpected object type: %T", obj)
+				return
+			}
+			r.queue.Add(client.ObjectKeyFromObject(claim))
+		},
+		UpdateFunc: func(oldObj, newObj any) {
+			claim, ok := newObj.(*metalv1alpha1.ServerClaim)
+			if !ok {
+				klog.Errorf("unexpected object type: %T", newObj)
+				return
+			}
+			r.queue.Add(client.ObjectKeyFromObject(claim))
+		},
+		DeleteFunc: func(obj any) {
+			if deleted, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = deleted.Obj
+			}
+			claim, ok := obj.(*metalv1alpha1.ServerClaim)
+			if !ok {
+				klog.Errorf("unexpected object type: %T", obj)
+				return
+			}
+			key := client.ObjectKeyFromObject(claim)
+			r.queue.Forget(key)
+			r.queue.Done(key)
+		},
+	})
+	defer r.queue.ShutDown()
+	if err != nil {
+		return fmt.Errorf("failed to add event handler: %w", err)
+	}
+	go func() {
+		for {
+			key, quit := r.queue.Get()
+			if quit {
+				return
+			}
+			if err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err != nil {
+				klog.Errorf("Failed to reconcile ServerClaim %s: %v", key, err)
+				r.queue.AddRateLimited(key)
+			}
+			r.queue.Done(key)
+		}
+	}()
+	<-ctx.Done()
+	klog.Info("Stopping ServerClaim reconciler")
+	return nil
+}
+
+func (r *ServerClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) error {
+	klog.V(2).Infof("Reconciling ServerClaim %s", req.NamespacedName)
+
+	serverClaim := &metalv1alpha1.ServerClaim{}
+	if err := r.metalClient.Get(ctx, req.NamespacedName, serverClaim); err != nil {
+		if client.IgnoreNotFound(err) != nil {
+			return err
+		}
+		klog.V(2).Infof("ServerClaim %s not found, skipping reconciliation", req.NamespacedName)
+		return nil
+	}
+
+	providerID := fmt.Sprintf("%s://%s/%s", ProviderName, serverClaim.Namespace, serverClaim.Name)
+	var nodes corev1.NodeList
+	err := r.targetClient.List(ctx, &nodes, client.MatchingFields{nodeProviderIDField: providerID})
+	if err != nil {
+		return fmt.Errorf("failed to list nodes with providerID %s: %w", providerID, err)
+	}
+	if len(nodes.Items) == 0 {
+		klog.V(2).Infof("No nodes found with providerID %s", providerID)
+		return nil
+	}
+	if len(nodes.Items) > 1 {
+		return fmt.Errorf("multiple nodes found with providerID %s", providerID)
+	}
+	node := nodes.Items[0]
+	if node.Labels == nil {
+		node.Labels = make(map[string]string)
+	}
+	originalNode := node.DeepCopy()
+	maintenanceVal := serverClaim.Labels[metalv1alpha1.ServerMaintenanceNeededLabelKey]
+	if maintenanceVal == "true" {
+		node.Labels[metalv1alpha1.ServerMaintenanceNeededLabelKey] = "true"
+	} else {
+		delete(node.Labels, metalv1alpha1.ServerMaintenanceNeededLabelKey)
+	}
+	return r.targetClient.Patch(ctx, &node, client.MergeFrom(originalNode))
+}

--- a/pkg/cloudprovider/metal/serverclaim_controller_test.go
+++ b/pkg/cloudprovider/metal/serverclaim_controller_test.go
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and IronCore contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package metal
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	. "sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+
+	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("ServerClaimReconciler", func() {
+
+	var (
+		serverClaim *metalv1alpha1.ServerClaim
+		node        *corev1.Node
+	)
+
+	ns, cp, _ := SetupTest(CloudConfig{
+		ClusterName: "test-cluster",
+	})
+
+	BeforeEach(func(ctx SpecContext) {
+		var ok bool
+		instancesProvider, ok = (*cp).InstancesV2()
+		Expect(ok).To(BeTrue())
+
+		By("Creating a Server")
+		server := &metalv1alpha1.Server{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Labels: map[string]string{
+					metalv1alpha1.InstanceTypeAnnotation: "foo",
+					corev1.LabelTopologyZone:             "a",
+					corev1.LabelTopologyRegion:           "bar",
+				},
+			},
+			Spec: metalv1alpha1.ServerSpec{
+				UUID:  "12345",
+				Power: "On",
+			},
+		}
+		Expect(k8sClient.Create(ctx, server)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, server)
+
+		By("Patching the Server object to have a valid network interface status")
+		Eventually(UpdateStatus(server, func() {
+			server.Status.PowerState = metalv1alpha1.ServerOnPowerState
+			server.Status.NetworkInterfaces = []metalv1alpha1.NetworkInterface{{
+				Name: "my-nic",
+				IP:   metalv1alpha1.MustParseIP("10.0.0.1"),
+			}}
+		})).Should(Succeed())
+
+		By("Creating a ServerClaim for a Node")
+		serverClaim = &metalv1alpha1.ServerClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    ns.Name,
+				GenerateName: "test-",
+			},
+			Spec: metalv1alpha1.ServerClaimSpec{
+				Power:     "On",
+				ServerRef: &corev1.LocalObjectReference{Name: server.Name},
+			},
+		}
+		Expect(k8sClient.Create(ctx, serverClaim)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, serverClaim)
+
+		By("Creating a Node object with a provider ID referencing the machine")
+		node = &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+			},
+		}
+		Expect(k8sClient.Create(ctx, node)).To(Succeed())
+		DeferCleanup(k8sClient.Delete, node)
+
+		By("Updating the SystemUUID in Node status")
+		Eventually(UpdateStatus(node, func() {
+			node.Status.NodeInfo.SystemUUID = "12345"
+		})).Should(Succeed())
+
+		By("Ensuring that an instance for a Node exists")
+		ok, err := instancesProvider.InstanceExists(ctx, node)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+
+		By("Ensuring that the Node has a provider ID")
+		meta, err := instancesProvider.InstanceMetadata(ctx, node)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(meta).NotTo(BeNil())
+
+		originalNode := node.DeepCopy()
+		node.Spec.ProviderID = meta.ProviderID
+		Expect(k8sClient.Patch(ctx, node, client.MergeFrom(originalNode))).To(Succeed())
+	})
+
+	It("should not change the labels of an operational node", func(ctx SpecContext) {
+		originalNode := node.DeepCopy()
+		testLabels := map[string]string{
+			"test-label": "test-value",
+		}
+		node.Labels = testLabels
+		Expect(k8sClient.Patch(ctx, node, client.MergeFrom(originalNode))).To(Succeed())
+		Consistently(Object(node)).Should(HaveField("Labels", testLabels))
+	})
+
+	It("should copy over the maintenance needed label", func(ctx SpecContext) {
+		originalServerClaim := serverClaim.DeepCopy()
+		serverClaim.Labels = map[string]string{
+			metalv1alpha1.ServerMaintenanceNeededLabelKey: "true",
+		}
+		Expect(k8sClient.Patch(ctx, serverClaim, client.MergeFrom(originalServerClaim))).To(Succeed())
+
+		Eventually(Object(node)).Should(HaveField("Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceNeededLabelKey, "true")))
+		Consistently(Object(node)).Should(HaveField("Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceNeededLabelKey, "true")))
+	})
+
+	It("should remove the maintenance needed label when not needed", func(ctx SpecContext) {
+		originalNode := node.DeepCopy()
+		node.Labels = map[string]string{
+			metalv1alpha1.ServerMaintenanceNeededLabelKey: "true",
+		}
+		Expect(k8sClient.Patch(ctx, node, client.MergeFrom(originalNode))).To(Succeed())
+		Eventually(Object(node)).Should(HaveField("Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceNeededLabelKey, "true")))
+
+		// Trigger the reconciler to remove the label
+		originalServerClaim := serverClaim.DeepCopy()
+		serverClaim.Labels = map[string]string{"a": "b"}
+		Expect(k8sClient.Patch(ctx, serverClaim, client.MergeFrom(originalServerClaim))).To(Succeed())
+
+		Eventually(Object(node)).Should(HaveField("Labels", BeEmpty()))
+		Consistently(Object(node)).Should(HaveField("Labels", BeEmpty()))
+	})
+})


### PR DESCRIPTION
# Proposed Changes

- Add a `ServerClaim` controller, which copies the `maintenance-needed` label from `ServerClaims` to the corresponding node

Part of #102.