### PR TITLE
Enhance node controller to assign pod prefix to node object

### DIFF
--- a/pkg/cloudprovider/metal/config.go
+++ b/pkg/cloudprovider/metal/config.go
@@ -41,11 +41,13 @@ type CloudConfig struct {
 var (
 	MetalKubeconfigPath string
 	MetalNamespace      string
+	PodPrefixSize       int
 )
 
 func AddExtraFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&MetalKubeconfigPath, "metal-kubeconfig", "", "Path to the metal cluster kubeconfig.")
 	fs.StringVar(&MetalNamespace, "metal-namespace", "", "Override metal cluster namespace.")
+	fs.IntVar(&PodPrefixSize, "pod-prefix-size", 0, "Prefix size for the pod prefix, zero or less disables pod prefix assignment.")
 }
 
 func LoadCloudProviderConfig(f io.Reader) (*CloudProviderConfig, error) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable --pod-prefix-size flag to control pod network prefix sizing.
  * Automatic pod CIDR computation and assignment based on node internal IPs.
* **Bug Fixes**
  * Improved error handling and validation during node reconciliation and network configuration patches.
* **Tests**
  * Expanded tests covering CIDR masking and assignment behavior for IPv4 and IPv6.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->