### PR TITLE
Handle cache miss error in the server-maintenance flow

### DIFF
--- a/pkg/cloudprovider/metal/node_controller.go
+++ b/pkg/cloudprovider/metal/node_controller.go
@@ -338,7 +338,13 @@ func (r *NodeReconciler) ensureServerMaintenanceExists(ctx context.Context, key 
 		return nil
 	})
 
-	return err
+	// Ignore AlreadyExists errors caused by informer cache delays.
+	// Adding a finalizer to the Node earlier in the Reconcile loop triggers an
+	// immediate re-reconciliation. This second run often happens so fast that the
+	// local cache hasn't received the newly created ServerMaintenance CR yet.
+	// As a result, CreateOrPatch gets a cache miss (NotFound) and attempts to
+	// Create the CR again, which the API server correctly rejects with AlreadyExists.
+	return client.IgnoreAlreadyExists(err)
 }
 
 func (r *NodeReconciler) syncServerClaimApproval(ctx context.Context, serverClaim *metalv1alpha1.ServerClaim, shouldHaveApproval bool) error {


### PR DESCRIPTION
fixes error logs in the `ServerMaintenance` creation flow
```
2026-03-06T09:55:00.213742268Z I0306 09:55:00.213654       1 node_controller.go:114] Reconciling Node /worker-rt-qa-de-1-kkxfs-6p7vr
2026-03-06T09:55:00.225785829Z I0306 09:55:00.225575       1 node_controller.go:114] Reconciling Node /worker-rt-qa-de-1-kkxfs-6p7vr
2026-03-06T09:55:00.231892743Z E0306 09:55:00.231742       1 node_controller.go:99] Failed to reconcile Node /worker-rt-qa-de-1-kkxfs-6p7vr: unable to reconcile maintenance: unable to ensure ServerMaintenance CR exists: servermaintenances.metal.ironcore.dev "worker-rt-qa-de-1-kkxfs-6p7vr" already exists
```

Current flow:
1. 'maintenance-requested' label is added to the Node, triggering Reconcile_1
2. Reconcile_1 adds the maintenance finalizer to the Node and calls `Patch()`
3. This `Patch()` updates the Node, which immediately sends an UPDATE event back to our Node informer, queueing Reconcile_2
4. Reconcile_1 continues and successfully creates the `ServerMaintenance` CR
5. Reconcile_2 starts almost instantly (triggered by the finalizer patch)
6. Reconcile_2 reaches this function and `CreateOrPatch()` calls `Get()` against the local cache. Because `Reconcile_2` started so fast, the cache has not yet received the new CR created in Step 4. `Get()` returns `ErrNotFound`
7. `CreateOrPatch()` assumes the CR is missing and attempts to `Create()` it again.
8. The API server rejects the second Create with an `ErrAlreadyExists`

So we want to ignore this `ErrAlreadyExists`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for server maintenance operations to prevent retry loops caused by concurrent creation events and timing issues. The system now gracefully manages situations when server maintenance records are created during reconciliation, reducing unnecessary operations and enhancing overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->