### PR TITLE
Add optional kustomization to grant metal permissions

### DIFF
--- a/config/metal-rbac/cluster_role.yaml
+++ b/config/metal-rbac/cluster_role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: metal-resources
+rules:
+  - apiGroups:
+      - metal.ironcore.dev
+    resources:
+      - servers
+    verbs:
+      - get

--- a/config/metal-rbac/cluster_role_binding.yaml
+++ b/config/metal-rbac/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: metal-resources
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: metal-resources
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system

--- a/config/metal-rbac/kustomization.yaml
+++ b/config/metal-rbac/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - cluster_role.yaml
+  - cluster_role_binding.yaml
+  - role.yaml
+  - role_binding.yaml

--- a/config/metal-rbac/role.yaml
+++ b/config/metal-rbac/role.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: metal-resources
+  namespace: kube-system
+rules:
+  - apiGroups:
+      - metal.ironcore.dev
+    resources:
+      - serverclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+  - apiGroups:
+      - ipam.cluster.x-k8s.io
+    resources:
+      - ipaddressclaims
+    verbs:
+      - list
+  - apiGroups:
+      - ipam.cluster.x-k8s.io
+    resources:
+      - ipaddresses
+    verbs:
+      - get

--- a/config/metal-rbac/role_binding.yaml
+++ b/config/metal-rbac/role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: metal-resources
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: metal-resources
+subjects:
+  - kind: ServiceAccount
+    name: cloud-controller-manager
+    namespace: kube-system


### PR DESCRIPTION
Add a second RBAC kustomization which covers the necessary roles to extend the existing service account to be able to interact with the Metal-API resources. It is opt-in to preserve the principle of least privilege, users should only add it when they know it is the right solution for their use-case.

This allows the provider to use a single service account to manage all resources when it's running in a self-hosted cluster in which both the node and server objects exist.

Resolves: #167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Kubernetes RBAC configuration to grant the cloud-controller-manager access to metal server and related networking resources.
  * Introduced scoped cluster- and namespace-level roles and bindings plus a kustomize manifest to include these RBAC pieces for easier deployment and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->