### PR TITLE
Exclude logic with deprecated maintenance label key

### DIFF
--- a/pkg/cloudprovider/metal/node_controller.go
+++ b/pkg/cloudprovider/metal/node_controller.go
@@ -294,12 +294,10 @@ func (r *NodeReconciler) reconcileMaintenance(ctx context.Context, node *corev1.
 	}
 
 	maintenanceNeeded := serverClaim.Labels[metalv1alpha1.ServerMaintenanceNeededLabelKey] == TrueStr
-	maintenanceApproved := node.Labels[metalv1alpha1.ServerMaintenanceApprovedLabelKey] == TrueStr ||
-		node.Labels[metalv1alpha1.ServerMaintenanceApprovalKey] == TrueStr
+	maintenanceApproved := node.Labels[metalv1alpha1.ServerMaintenanceApprovedLabelKey] == TrueStr
 
 	shouldHaveApproval := maintenanceNeeded && maintenanceApproved
-	hasApproval := serverClaim.Labels[metalv1alpha1.ServerMaintenanceApprovedLabelKey] == TrueStr ||
-		serverClaim.Labels[metalv1alpha1.ServerMaintenanceApprovalKey] == TrueStr
+	hasApproval := serverClaim.Labels[metalv1alpha1.ServerMaintenanceApprovedLabelKey] == TrueStr
 
 	if shouldHaveApproval != hasApproval {
 		if err = r.syncServerClaimApproval(ctx, serverClaim, shouldHaveApproval); err != nil {
@@ -357,15 +355,13 @@ func (r *NodeReconciler) syncServerClaimApproval(ctx context.Context, serverClai
 			serverClaim.Labels = make(map[string]string)
 		}
 		serverClaim.Labels[metalv1alpha1.ServerMaintenanceApprovedLabelKey] = TrueStr
-		serverClaim.Labels[metalv1alpha1.ServerMaintenanceApprovalKey] = TrueStr // deprecated, kept for backward compatibility
 
 	} else {
 		delete(serverClaim.Labels, metalv1alpha1.ServerMaintenanceApprovedLabelKey)
-		delete(serverClaim.Labels, metalv1alpha1.ServerMaintenanceApprovalKey)
 	}
 
 	if err := r.metalClient.Patch(ctx, serverClaim, client.MergeFrom(base)); err != nil {
-		return fmt.Errorf("unable to patch ServerClaim approval label: %w", err)
+		return fmt.Errorf("unable to patch ServerClaim approved label: %w", err)
 	}
 
 	return nil

--- a/pkg/cloudprovider/metal/node_controller_test.go
+++ b/pkg/cloudprovider/metal/node_controller_test.go
@@ -438,7 +438,7 @@ var _ = Describe("NodeReconciler", func() {
 	})
 
 	Context("Maintenance Approval Handshake", func() {
-		It("should add both approval labels to the ServerClaim when Node is approved with the new key", func(ctx SpecContext) {
+		It("should add approved label to the ServerClaim when Node is approved with the new key", func(ctx SpecContext) {
 			By("Adding maintenance-needed label to the ServerClaim")
 			Eventually(Update(serverClaim, func() {
 				if serverClaim.Labels == nil {
@@ -455,38 +455,13 @@ var _ = Describe("NodeReconciler", func() {
 				node.Labels[metalv1alpha1.ServerMaintenanceApprovedLabelKey] = TrueStr
 			})).Should(Succeed())
 
-			By("Verifying the ServerClaim receives both the new and the deprecated approval labels")
+			By("Verifying the ServerClaim receives approved label")
 			Eventually(Object(serverClaim)).Should(SatisfyAll(
 				HaveField("Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceApprovedLabelKey, TrueStr)),
-				HaveField("Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceApprovalKey, TrueStr)),
 			))
 		})
 
-		It("should add both approval labels to the ServerClaim when Node uses the deprecated approval key (backward compatibility)", func(ctx SpecContext) {
-			By("Adding maintenance-needed label to the ServerClaim")
-			Eventually(Update(serverClaim, func() {
-				if serverClaim.Labels == nil {
-					serverClaim.Labels = make(map[string]string)
-				}
-				serverClaim.Labels[metalv1alpha1.ServerMaintenanceNeededLabelKey] = TrueStr
-			})).Should(Succeed())
-
-			By("Adding the deprecated maintenance-approval label to the Node")
-			Eventually(Update(node, func() {
-				if node.Labels == nil {
-					node.Labels = make(map[string]string)
-				}
-				node.Labels[metalv1alpha1.ServerMaintenanceApprovalKey] = TrueStr
-			})).Should(Succeed())
-
-			By("Verifying the ServerClaim receives both the new and the deprecated approval labels")
-			Eventually(Object(serverClaim)).Should(SatisfyAll(
-				HaveField("Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceApprovedLabelKey, TrueStr)),
-				HaveField("Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceApprovalKey, TrueStr)),
-			))
-		})
-
-		It("should remove both approval labels from the ServerClaim when Node loses the approval label", func(ctx SpecContext) {
+		It("should remove approved label from the ServerClaim when Node loses the approved label", func(ctx SpecContext) {
 			By("Setting up the initial approved state")
 			Eventually(Update(serverClaim, func() {
 				if serverClaim.Labels == nil {
@@ -504,22 +479,20 @@ var _ = Describe("NodeReconciler", func() {
 
 			Eventually(Object(serverClaim)).Should(SatisfyAll(
 				HaveField("Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceApprovedLabelKey, TrueStr)),
-				HaveField("Labels", HaveKeyWithValue(metalv1alpha1.ServerMaintenanceApprovalKey, TrueStr)),
 			))
 
-			By("Removing the approval label from the Node")
+			By("Removing the approved label from the Node")
 			Eventually(Update(node, func() {
 				delete(node.Labels, metalv1alpha1.ServerMaintenanceApprovedLabelKey)
 			})).Should(Succeed())
 
-			By("Verifying both approval labels are removed from the ServerClaim")
+			By("Verifying approved label is removed from the ServerClaim")
 			Eventually(Object(serverClaim)).Should(SatisfyAll(
 				HaveField("Labels", Not(HaveKey(metalv1alpha1.ServerMaintenanceApprovedLabelKey))),
-				HaveField("Labels", Not(HaveKey(metalv1alpha1.ServerMaintenanceApprovalKey))),
 			))
 		})
 
-		It("should NOT add the approval labels to the ServerClaim if maintenance was not needed", func(ctx SpecContext) {
+		It("should NOT add approved label to the ServerClaim if maintenance was not needed", func(ctx SpecContext) {
 			By("Adding maintenance-approved label to the Node without needed label on Claim")
 			Eventually(Update(node, func() {
 				if node.Labels == nil {
@@ -528,10 +501,9 @@ var _ = Describe("NodeReconciler", func() {
 				node.Labels[metalv1alpha1.ServerMaintenanceApprovedLabelKey] = TrueStr
 			})).Should(Succeed())
 
-			By("Ensuring the ServerClaim does not get any approval label")
+			By("Ensuring the ServerClaim does not get approved label")
 			Consistently(Object(serverClaim)).Should(SatisfyAll(
 				HaveField("Labels", Not(HaveKey(metalv1alpha1.ServerMaintenanceApprovedLabelKey))),
-				HaveField("Labels", Not(HaveKey(metalv1alpha1.ServerMaintenanceApprovalKey))),
 			))
 		})
 	})


### PR DESCRIPTION
# Proposed Changes

- After bumped version of metal-operator to v0.5.0 all associated backward-compatibility logic is removed
- Removed reads of the deprecated ServerMaintenanceApprovalKey label in reconcileMaintenance
- Removed writes of the deprecated ServerMaintenanceApprovalKey label in syncServerClaimApproval
- Removed deletion of the deprecated ServerMaintenanceApprovalKey label on revocation in syncServerClaimApproval
- Removed and updated related tests

Fixes #173 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed support for a deprecated maintenance-approval label; the system now relies solely on the updated approval label.
  * Approval creation and removal now consistently use only the updated label.
  * Tests updated to validate the new label behavior.
  * No changes to public interfaces or user-facing approval workflow beyond label consolidation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/cloud-provider-metal/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->