### PR TITLE
Replace unstructured klog calls with structured logging

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,0 +1,11 @@
+# This file configures golangci-lint with module plugins.
+# When you run 'make lint', it will automatically build a custom golangci-lint binary
+# with all the plugins listed below.
+#
+# See: https://golangci-lint.run/plugins/module-plugins/
+version: v2.11.4
+plugins:
+  # logcheck validates structured logging calls and parameters (e.g., balanced key-value pairs)
+  - module: "sigs.k8s.io/logtools"
+    import: "sigs.k8s.io/logtools/logcheck/gclplugin"
+    version: latest

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,9 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
+  - title: '🌟 Highlights'
+    labels:
+      - 'highlight'
   - title: '⚠️ Breaking'
     labels:
       - 'breaking'
@@ -13,11 +16,14 @@ categories:
       - 'fix'
       - 'bugfix'
       - 'bug'
+  - title: '⚠️ Deprecations'
+    labels:
+      - 'deprecation'
   - title: '🧰 Maintenance'
     labels:
       - 'chore'
       - 'dependencies'
-      - 'documentation'
+      - 'marketing'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,4 +17,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10
+          version: v2.12

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,30 +1,39 @@
 name: Release Drafter
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
       - release-**
   pull_request_target:
     types: [ opened, reopened, synchronize ]
-  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   update_release_draft:
     name: Run release drafter
+    if: github.event_name != 'pull_request_target'
     permissions:
-      # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       # or a release branch
       - uses: release-drafter/release-drafter@v7
         with:
-          config-name: release-drafter.yml
           commitish: ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+  auto_label:
+    name: Run autolabeler
+    if: github.event_name == 'pull_request_target'
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter/autolabeler@v7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,24 +13,36 @@ linters:
     - govet
     - ineffassign
     - lll
+    - modernize
     - misspell
     - nakedret
     - prealloc
+    - revive
     - staticcheck
     - unconvert
     - unparam
     - unused
+    - logcheck
+  settings:
+    custom:
+      logcheck:
+        type: "module"
+        description: Checks Go logging calls for Kubernetes logging conventions.
+    revive:
+      rules:
+        - name: comment-spacings
+        - name: import-shadowing
+    modernize:
+      disable:
+        - omitzero
   exclusions:
     generated: lax
     rules:
       - linters:
           - lll
           - dupl
-        path: cmd/*
-      - linters:
-          - lll
-          - dupl
-        path: pkg/*
+          - goconst
+        path: pkg/cloudprovider/metal/*
     paths:
       - third_party$
       - builtin$

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,16 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint on the code.
-	$(GOLANGCI_LINT) run ./...
+lint: golangci-lint ## Run golangci-lint linter
+	"$(GOLANGCI_LINT)" run --max-same-issues=0
+
+.PHONY: lint-fix
+lint-fix: golangci-lint ## Run golangci-lint linter and perform fixes
+	"$(GOLANGCI_LINT)" run --fix
+
+.PHONY: lint-config
+lint-config: golangci-lint ## Verify golangci-lint linter configuration
+	"$(GOLANGCI_LINT)" config verify
 
 .PHONY: test
 test: fmt vet envtest check-license ## Run tests.
@@ -125,8 +133,8 @@ GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
 ADDLICENSE_VERSION ?= v1.1.1
-GOIMPORTS_VERSION ?= v0.31.0
-GOLANGCI_LINT_VERSION ?= v2.10
+GOIMPORTS_VERSION ?= v0.45.0
+GOLANGCI_LINT_VERSION ?= v2.12
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
@@ -151,6 +159,11 @@ $(GOIMPORTS): $(LOCALBIN)
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
 	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	@test -f .custom-gcl.yml && { \
+		echo "Building custom golangci-lint with plugins..." && \
+		$(GOLANGCI_LINT) custom --destination $(LOCALBIN) --name golangci-lint-custom && \
+		mv -f $(LOCALBIN)/golangci-lint-custom $(GOLANGCI_LINT); \
+	} || true
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -7,6 +7,7 @@ SPDX-PackageDownloadLocation = "https://github.com/ironcore-dev/cloud-provider-m
 path = [
     ".github/**",
     ".gitignore",
+    ".custom-gcl.yml",
     ".golangci.yml",
     ".dockerignore",
     "CODE_OF_CONDUCT.md",

--- a/cmd/metal-cloud-controller-manager/main.go
+++ b/cmd/metal-cloud-controller-manager/main.go
@@ -31,15 +31,21 @@ func main() {
 
 	ccmOptions, err := options.NewCloudControllerManagerOptions()
 	if err != nil {
-		klog.Fatalf("unable to initialize command options: %v", err)
+		klog.ErrorS(err, "unable to initialize command options")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
 	fss := cliflag.NamedFlagSets{}
 	metal.AddExtraFlags(fss.FlagSet("Metal Client"))
 
-	command := app.NewCloudControllerManagerCommand(ccmOptions, cloudInitializer, app.DefaultInitFuncConstructors, names.CCMControllerAliases(), fss, wait.NeverStop)
+	command := app.NewCloudControllerManagerCommand(ccmOptions,
+		cloudInitializer,
+		app.DefaultInitFuncConstructors,
+		names.CCMControllerAliases(),
+		fss,
+		wait.NeverStop)
 
-	klog.V(1).Infof("metal-cloud-controller-manager version: %s", version.Version)
+	klog.V(1).InfoS("metal-cloud-controller-manager version", "version", version.Version)
 
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -58,17 +64,22 @@ func cloudInitializer(config *cloudcontrollerconfig.CompletedConfig) cloudprovid
 	// initialize cloud provider with the cloud provider name and config file provided
 	cloud, err := cloudprovider.InitCloudProvider(providerName, cloudConfig.CloudConfigFile)
 	if err != nil {
-		klog.Fatalf("Cloud provider could not be initialized: %v", err)
+		klog.ErrorS(err, "cloud provider could not be initialized")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	if cloud == nil {
-		klog.Fatalf("Cloud provider is nil")
+		klog.ErrorS(nil, "cloud provider is nil")
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
 	if cloud != nil && !cloud.HasClusterID() {
 		if config.ComponentConfig.KubeCloudShared.AllowUntaggedCloud {
-			klog.Warning("detected a cluster without a ClusterID. A ClusterID will be required in the future. Please tag your cluster to avoid any future issues.")
+			klog.InfoS("WARNING: detected a cluster without a ClusterID", "detail",
+				"A ClusterID will be required in the future. Please tag your cluster to avoid any future issues.")
 		} else {
-			klog.Fatalf("no ClusterID found. A ClusterID is required for the cloud provider to function properly. This check can be bypassed by setting the allow-untagged-cloud option")
+			klog.ErrorS(nil, "No ClusterID found, a ClusterID is required for the cloud provider to function properly, "+
+				"this check can be bypassed by setting the allow-untagged-cloud option")
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
 	}
 

--- a/pkg/cloudprovider/metal/cloud.go
+++ b/pkg/cloudprovider/metal/cloud.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 
 	metalv1alpha1 "github.com/ironcore-dev/metal-operator/api/v1alpha1"
 	"github.com/pkg/errors"
@@ -79,11 +78,13 @@ func (o *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 
 	cfg, err := clientBuilder.Config("cloud-controller-manager")
 	if err != nil {
-		log.Fatalf("Failed to get config: %v", err)
+		klog.ErrorS(err, "Failed to get config", "provider", ProviderName)
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	o.targetCluster, err = cluster.New(cfg)
 	if err != nil {
-		log.Fatalf("Failed to create new cluster: %v", err)
+		klog.ErrorS(err, "Failed to create new cluster", "provider", ProviderName)
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
 	o.instancesV2 = newMetalInstancesV2(
@@ -97,7 +98,8 @@ func (o *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 		serverClaim := object.(*metalv1alpha1.ServerClaim)
 		return []string{string(serverClaim.UID)}
 	}); err != nil {
-		log.Fatalf("Failed to setup field indexer for server claims: %v", err)
+		klog.ErrorS(err, "Failed to setup field indexer for server claims", "provider", ProviderName)
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	if err := o.targetCluster.GetFieldIndexer().IndexField(ctx, &corev1.Node{}, NodeProviderIDField, func(object client.Object) []string {
 		node := object.(*corev1.Node)
@@ -106,49 +108,58 @@ func (o *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 		}
 		return []string{node.Spec.ProviderID}
 	}); err != nil {
-		log.Fatalf("Failed to setup field indexer for nodes: %v", err)
+		klog.ErrorS(err, "Failed to setup field indexer for nodes", "provider", ProviderName)
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
 	go func() {
 		if err := o.metalCluster.Start(ctx); err != nil {
-			log.Fatalf("Failed to start metal cluster: %v", err)
+			klog.ErrorS(err, "Failed to start metal cluster", "provider", ProviderName)
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
 	}()
 
 	go func() {
 		if err := o.targetCluster.Start(ctx); err != nil {
-			log.Fatalf("Failed to start target cluster: %v", err)
+			klog.ErrorS(err, "Failed to start target cluster", "provider", ProviderName)
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
 	}()
 
 	var serverClaim metalv1alpha1.ServerClaim
 	claimInformer, err := o.metalCluster.GetCache().GetInformer(ctx, &serverClaim)
 	if err != nil {
-		log.Fatalf("Failed to setup ServerClaim informer: %v", err)
+		klog.ErrorS(err, "Failed to setup ServerClaim informer", "provider", ProviderName)
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	serverClaimReconciler := NewServerClaimReconciler(o.targetCluster.GetClient(), o.metalCluster.GetClient(), claimInformer)
 	go func() {
 		if err := serverClaimReconciler.Start(ctx); err != nil {
-			log.Fatalf("Failed to start ServerClaim reconciler: %v", err)
+			klog.ErrorS(err, "Failed to start ServerClaim reconciler", "provider", ProviderName)
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
 	}()
 	var node corev1.Node
 	nodeInformer, err := o.targetCluster.GetCache().GetInformer(ctx, &node)
 	if err != nil {
-		log.Fatalf("Failed to setup Node informer: %v", err)
+		klog.ErrorS(err, "Failed to setup Node informer", "provider", ProviderName)
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	nodeReconciler := NewNodeReconciler(o.targetCluster.GetClient(), o.metalCluster.GetClient(), nodeInformer)
 	go func() {
 		if err := nodeReconciler.Start(ctx); err != nil {
-			log.Fatalf("Failed to start Node reconciler: %v", err)
+			klog.ErrorS(err, "Failed to start Node reconciler", "provider", ProviderName)
+			klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 		}
 	}()
 
 	if !o.metalCluster.GetCache().WaitForCacheSync(ctx) {
-		log.Fatal("Failed to wait for metal cluster cache to sync")
+		klog.ErrorS(nil, "Failed to wait for metal cluster cache to sync", "provider", ProviderName)
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	if !o.targetCluster.GetCache().WaitForCacheSync(ctx) {
-		log.Fatal("Failed to wait for target cluster cache to sync")
+		klog.ErrorS(nil, "Failed to wait for target cluster cache to sync", "provider", ProviderName)
+		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 	klog.V(2).InfoS("Successfully initialized cloud provider", "provider", ProviderName)
 }

--- a/pkg/cloudprovider/metal/cloud.go
+++ b/pkg/cloudprovider/metal/cloud.go
@@ -70,7 +70,7 @@ type cloud struct {
 }
 
 func (o *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, stop <-chan struct{}) {
-	klog.V(2).Infof("Initializing cloud provider: %s", ProviderName)
+	klog.V(2).InfoS("Initializing cloud provider", "provider", ProviderName)
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		defer cancel()
@@ -150,7 +150,7 @@ func (o *cloud) Initialize(clientBuilder cloudprovider.ControllerClientBuilder, 
 	if !o.targetCluster.GetCache().WaitForCacheSync(ctx) {
 		log.Fatal("Failed to wait for target cluster cache to sync")
 	}
-	klog.V(2).Infof("Successfully initialized cloud provider: %s", ProviderName)
+	klog.V(2).InfoS("Successfully initialized cloud provider", "provider", ProviderName)
 }
 
 func (o *cloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {

--- a/pkg/cloudprovider/metal/config.go
+++ b/pkg/cloudprovider/metal/config.go
@@ -51,7 +51,7 @@ func AddExtraFlags(fs *pflag.FlagSet) {
 }
 
 func LoadCloudProviderConfig(f io.Reader) (*CloudProviderConfig, error) {
-	klog.V(2).Infof("Reading configuration for cloud provider: %s", ProviderName)
+	klog.V(2).InfoS("Loading cloud provider config", "provider", ProviderName)
 	configBytes, err := io.ReadAll(f)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read in config")
@@ -82,7 +82,7 @@ func LoadCloudProviderConfig(f io.Reader) (*CloudProviderConfig, error) {
 		return nil, fmt.Errorf("got a empty namespace from metal kubeconfig")
 	}
 
-	klog.V(2).Infof("Successfully read configuration for cloud provider: %s", ProviderName)
+	klog.V(2).InfoS("Successfully loaded configuration", "provider", ProviderName)
 	return cloudProviderConfig, nil
 }
 

--- a/pkg/cloudprovider/metal/node_controller.go
+++ b/pkg/cloudprovider/metal/node_controller.go
@@ -56,7 +56,7 @@ func (r *NodeReconciler) Start(ctx context.Context) error {
 		AddFunc: func(obj any) {
 			node, ok := obj.(*corev1.Node)
 			if !ok {
-				klog.Errorf("unexpected object type: %T", obj)
+				klog.ErrorS(nil, "unexpected object type", "type", fmt.Sprintf("%T", obj))
 				return
 			}
 			r.queue.Add(client.ObjectKeyFromObject(node))
@@ -64,7 +64,7 @@ func (r *NodeReconciler) Start(ctx context.Context) error {
 		UpdateFunc: func(oldObj, newObj any) {
 			node, ok := newObj.(*corev1.Node)
 			if !ok {
-				klog.Errorf("unexpected object type: %T", newObj)
+				klog.ErrorS(nil, "unexpected object type", "type", fmt.Sprintf("%T", newObj))
 				return
 			}
 			r.queue.Add(client.ObjectKeyFromObject(node))
@@ -75,7 +75,7 @@ func (r *NodeReconciler) Start(ctx context.Context) error {
 			}
 			node, ok := obj.(*corev1.Node)
 			if !ok {
-				klog.Errorf("unexpected object type: %T", obj)
+				klog.ErrorS(nil, "unexpected object type", "type", fmt.Sprintf("%T", obj))
 				return
 			}
 			key := client.ObjectKeyFromObject(node)
@@ -96,7 +96,7 @@ func (r *NodeReconciler) Start(ctx context.Context) error {
 				defer r.queue.Done(key)
 
 				if err = r.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err != nil {
-					klog.Errorf("Failed to reconcile Node %s: %v", key, err)
+					klog.ErrorS(err, "Failed to reconcile Node", "node", key)
 					r.queue.AddRateLimited(key)
 					return
 				}
@@ -106,24 +106,24 @@ func (r *NodeReconciler) Start(ctx context.Context) error {
 		}
 	}()
 	<-ctx.Done()
-	klog.Info("Stopping Node reconciler")
+	klog.InfoS("Stopping Node reconciler")
 	return nil
 }
 
 func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) error {
-	klog.V(2).Infof("Reconciling Node %s", req.NamespacedName)
+	klog.V(2).InfoS("Reconciling Node", "node", req.NamespacedName)
 
 	node := &corev1.Node{}
 	if err := r.targetClient.Get(ctx, req.NamespacedName, node); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return err
 		}
-		klog.V(2).Infof("Node %s not found, skipping reconciliation", req.NamespacedName)
+		klog.V(2).InfoS("Node not found, skipping reconciliation", "node", req.NamespacedName)
 		return nil
 	}
 
 	if !node.DeletionTimestamp.IsZero() {
-		klog.V(2).Infof("Node %s is deleting, reconciling delete flow", req.NamespacedName)
+		klog.V(2).InfoS("Node is being deleted, reconciling delete flow", "node", req.NamespacedName)
 		return r.reconcileDelete(ctx, node)
 	}
 
@@ -145,7 +145,7 @@ func (r *NodeReconciler) reconcileDelete(ctx context.Context, node *corev1.Node)
 
 	serverClaimKey, err := getObjectKeyFromProviderID(node.Spec.ProviderID)
 	if err != nil {
-		klog.Errorf("Node %s has empty/invalid spec.providerID during node deletion: %v. Skipping CR cleanup to unblock node deletion", node.Name, err)
+		klog.ErrorS(err, "Node has empty/invalid spec.providerID during node deletion. Skipping CR cleanup to unblock node deletion", "node", node.Name)
 
 		base := node.DeepCopy()
 		if removed := controllerutil.RemoveFinalizer(node, nodeMaintenanceFinalizer); removed {
@@ -178,7 +178,7 @@ func (r *NodeReconciler) ensureServerMaintenanceNotExists(ctx context.Context, k
 	}
 
 	if maintenance.Labels == nil || maintenance.Labels[labelKeyManagedBy] != cloudProviderMetalName {
-		klog.Infof("ServerMaintenance %s exists but is not managed by CCM, skipping deletion", key)
+		klog.InfoS("ServerMaintenance exists but is not managed by CCM, skipping deletion", "servermaintenance", key)
 		return nil
 	}
 
@@ -227,7 +227,7 @@ func (r *NodeReconciler) reconcilePodCIDR(ctx context.Context, node *corev1.Node
 		}
 	}
 
-	klog.Info("Node does not have a NodeInternalIP, not setting podCIDR")
+	klog.InfoS("Node does not have a NodeInternalIP, not setting podCIDR")
 	return nil
 }
 
@@ -244,7 +244,7 @@ func zeroHostBits(ip net.IP, maskSize int) net.IP {
 func (r *NodeReconciler) reconcileMaintenance(ctx context.Context, node *corev1.Node) error {
 	serverClaimKey, err := getObjectKeyFromProviderID(node.Spec.ProviderID)
 	if err != nil {
-		klog.Errorf("Node %s has invalid spec.providerID: %v", node.Name, err)
+		klog.ErrorS(err, "Node has invalid spec.providerID", "node", node.Name, "providerID", node.Spec.ProviderID)
 		return nil
 	}
 
@@ -267,14 +267,14 @@ func (r *NodeReconciler) reconcileMaintenance(ctx context.Context, node *corev1.
 	serverClaim := &metalv1alpha1.ServerClaim{}
 	if err = r.metalClient.Get(ctx, serverClaimKey, serverClaim); err != nil {
 		if apierrors.IsNotFound(err) {
-			klog.V(2).Infof("ServerClaim %s not found, skipping maintenance creation and handshake", serverClaimKey)
+			klog.V(2).InfoS("ServerClaim not found, skipping maintenance creation and handshake", "serverclaim", serverClaimKey)
 			return nil
 		}
 		return fmt.Errorf("unable to get ServerClaim: %w", err)
 	}
 
 	if serverClaim.Spec.ServerRef == nil {
-		klog.V(2).Infof("ServerClaim %s has empty ServerRef, skipping maintenance logic", serverClaimKey)
+		klog.V(2).InfoS("ServerClaim has empty ServerRef, skipping maintenance logic", "serverclaim", serverClaimKey)
 		return nil
 	}
 

--- a/pkg/cloudprovider/metal/serverclaim_controller.go
+++ b/pkg/cloudprovider/metal/serverclaim_controller.go
@@ -42,7 +42,7 @@ func (r *ServerClaimReconciler) Start(ctx context.Context) error {
 		AddFunc: func(obj any) {
 			claim, ok := obj.(*metalv1alpha1.ServerClaim)
 			if !ok {
-				klog.Errorf("unexpected object type: %T", obj)
+				klog.ErrorS(nil, "unexpected object type", "type", fmt.Sprintf("%T", obj))
 				return
 			}
 			r.queue.Add(client.ObjectKeyFromObject(claim))
@@ -50,7 +50,7 @@ func (r *ServerClaimReconciler) Start(ctx context.Context) error {
 		UpdateFunc: func(oldObj, newObj any) {
 			claim, ok := newObj.(*metalv1alpha1.ServerClaim)
 			if !ok {
-				klog.Errorf("unexpected object type: %T", newObj)
+				klog.ErrorS(nil, "unexpected object type", "type", fmt.Sprintf("%T", newObj))
 				return
 			}
 			r.queue.Add(client.ObjectKeyFromObject(claim))
@@ -61,7 +61,7 @@ func (r *ServerClaimReconciler) Start(ctx context.Context) error {
 			}
 			claim, ok := obj.(*metalv1alpha1.ServerClaim)
 			if !ok {
-				klog.Errorf("unexpected object type: %T", obj)
+				klog.ErrorS(nil, "unexpected object type", "type", fmt.Sprintf("%T", obj))
 				return
 			}
 			key := client.ObjectKeyFromObject(claim)
@@ -80,26 +80,26 @@ func (r *ServerClaimReconciler) Start(ctx context.Context) error {
 				return
 			}
 			if err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err != nil {
-				klog.Errorf("Failed to reconcile ServerClaim %s: %v", key, err)
+				klog.ErrorS(err, "Failed to reconcile ServerClaim", "serverclaim", key)
 				r.queue.AddRateLimited(key)
 			}
 			r.queue.Done(key)
 		}
 	}()
 	<-ctx.Done()
-	klog.Info("Stopping ServerClaim reconciler")
+	klog.InfoS("Stopping ServerClaim reconciler")
 	return nil
 }
 
 func (r *ServerClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) error {
-	klog.V(2).Infof("Reconciling ServerClaim %s", req.NamespacedName)
+	klog.V(2).InfoS("Reconciling ServerClaim", "serverclaim", req.NamespacedName)
 
 	serverClaim := &metalv1alpha1.ServerClaim{}
 	if err := r.metalClient.Get(ctx, req.NamespacedName, serverClaim); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return err
 		}
-		klog.V(2).Infof("ServerClaim %s not found, skipping reconciliation", req.NamespacedName)
+		klog.V(2).InfoS("ServerClaim not found, skipping reconciliation", "serverclaim", req.NamespacedName)
 		return nil
 	}
 
@@ -110,7 +110,7 @@ func (r *ServerClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return fmt.Errorf("failed to list nodes with providerID %s: %w", providerID, err)
 	}
 	if len(nodes.Items) == 0 {
-		klog.V(2).Infof("No nodes found with providerID %s", providerID)
+		klog.V(2).InfoS("No nodes found", "providerID", providerID)
 		return nil
 	}
 	if len(nodes.Items) > 1 {

--- a/pkg/cloudprovider/metal/suite_test.go
+++ b/pkg/cloudprovider/metal/suite_test.go
@@ -86,8 +86,6 @@ var _ = BeforeSuite(func() {
 	Expect(metalv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(capiv1beta1.AddToScheme(scheme.Scheme)).To(Succeed())
 
-	//+kubebuilder:scaffold:scheme
-
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())


### PR DESCRIPTION
# Proposed Changes

Fix logcheck linter warnings by replacing unstructured logging functions (Fatalf, Errorf, Fatal) with their structured equivalents (ErrorS).

Fatal calls are replaced with ErrorS followed by FlushAndExit to maintain the same exit behavior while satisfying the structured logging requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced linting infrastructure with expanded code quality checks.
  * Upgraded tooling versions for improved code analysis.
  * Improved GitHub Actions workflows for release management and automated labeling.
  * Updated error handling and logging for better operational diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ironcore-dev/cloud-provider-metal/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->